### PR TITLE
refactor: change Asset entity ID from Long to UUID for consistency

### DIFF
--- a/backend/wallet/src/main/java/pl/muybien/asset/Asset.java
+++ b/backend/wallet/src/main/java/pl/muybien/asset/Asset.java
@@ -12,6 +12,7 @@ import pl.muybien.enums.UnitType;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Builder
@@ -25,9 +26,9 @@ import java.time.LocalDateTime;
 public class Asset {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @EqualsAndHashCode.Include
-    private Long id;
+    private UUID id;
 
     private String name;
 

--- a/backend/wallet/src/main/java/pl/muybien/asset/AssetController.java
+++ b/backend/wallet/src/main/java/pl/muybien/asset/AssetController.java
@@ -46,7 +46,7 @@ public class AssetController {
     public ResponseEntity<AssetHistoryDTO> updateAsset(
             @RequestHeader("X-Customer-Id") String customerId,
             @RequestBody @Valid AssetRequest request,
-            @PathVariable("asset-id") Long assetId
+            @PathVariable("asset-id") String assetId
     ) {
         return ResponseEntity.ok(service.updateAsset(customerId, request, assetId));
     }
@@ -54,7 +54,7 @@ public class AssetController {
     @DeleteMapping("/{asset-id}")
     public ResponseEntity<String> deleteAsset(
             @RequestHeader("X-Customer-Id") String customerId,
-            @PathVariable("asset-id") Long assetId) {
+            @PathVariable("asset-id") String assetId) {
         service.deleteAsset(customerId, assetId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/backend/wallet/src/main/java/pl/muybien/asset/AssetService.java
+++ b/backend/wallet/src/main/java/pl/muybien/asset/AssetService.java
@@ -79,8 +79,8 @@ public class AssetService {
     }
 
     @Transactional
-    public AssetHistoryDTO updateAsset(String customerId, AssetRequest request, Long assetId) {
-        var asset = repository.findById(assetId).orElseThrow(() ->
+    public AssetHistoryDTO updateAsset(String customerId, AssetRequest request, String assetId) {
+        var asset = repository.findById(UUID.fromString(assetId)).orElseThrow(() ->
                 new AssetNotFoundException("Asset with ID %s not found".formatted(assetId)));
 
         boolean customerIsNotOwner = !customerId.equals(asset.getCustomerId());
@@ -128,8 +128,8 @@ public class AssetService {
     }
 
     @Transactional
-    public void deleteAsset(String customerId, Long assetId) {
-        var asset = repository.findById(assetId).orElseThrow(() ->
+    public void deleteAsset(String customerId, String assetId) {
+        var asset = repository.findById(UUID.fromString(assetId)).orElseThrow(() ->
                 new EntityNotFoundException("Asset with ID: %s not found".formatted(assetId)));
 
         boolean customerIsNotOwner = !customerId.equals(asset.getCustomerId());

--- a/backend/wallet/src/main/java/pl/muybien/asset/dto/AssetHistoryDTO.java
+++ b/backend/wallet/src/main/java/pl/muybien/asset/dto/AssetHistoryDTO.java
@@ -7,9 +7,10 @@ import pl.muybien.enums.UnitType;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record AssetHistoryDTO(
-        @JsonProperty("id") Long id,
+        @JsonProperty("id") UUID id,
         @JsonProperty("name") String name,
         @JsonProperty("uri") String uri,
         @JsonProperty("symbol") String symbol,


### PR DESCRIPTION
- Update Asset entity to use UUID instead of Long for ID field
- Change ID generation strategy from IDENTITY to UUID
- Update AssetController to accept String UUIDs in path variables
- Modify AssetService methods to handle UUID string parameters
- Update AssetHistoryDTO to use UUID type
- Fix all test cases to use UUID strings instead of Long IDs
- Maintain API compatibility while ensuring UUID consistency across entities